### PR TITLE
Revert "chore(deps): update docker image quay.io/metallb/speaker to v0.13.10"

### DIFF
--- a/projects/core/values/metallb.yaml
+++ b/projects/core/values/metallb.yaml
@@ -22,4 +22,4 @@ controller:
 speaker:
   image:
     repository: quay.io/metallb/speaker
-    tag: v0.13.10
+    tag: v0.13.9


### PR DESCRIPTION
Reverts Nold360/hive-apps#1611

Error:
```
│ E0601 13:21:34.650441       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:m │
│ W0601 13:21:42.108637       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:metallb-speaker" cannot list res │
│ E0601 13:21:42.108669       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:m │
│ W0601 13:22:04.942588       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:metallb-speaker" cannot list res │
│ E0601 13:22:04.942678       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:m │
│ W0601 13:22:49.832243       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:metallb-speaker" cannot list res │
│ E0601 13:22:49.832282       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.4/tools/cache/reflector.go:169: Failed to watch *v1.ConfigMap: failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:metallb:m │
│ {"level":"error","ts":"2023-06-01T13:23:27Z","msg":"Could not wait for Cache to sync","controller":"bgppeer","controllerGroup":"metallb.io","controllerKind":"BGPPeer","error":"failed to wait for bgppeer caches to sync: timed out waiti │
│ {"level":"error","ts":"2023-06-01T13:23:27Z","msg":"Could not wait for Cache to sync","controller":"node","controllerGroup":"","controllerKind":"Node","error":"failed to wait for node caches to sync: timed out waiting for cache to be  │
│ {"level":"error","ts":"2023-06-01T13:23:27Z","msg":"Could not wait for Cache to sync","controller":"service","controllerGroup":"","controllerKind":"Service","error":"failed to wait for service caches to sync: timed out waiting for cac │
│ {"level":"info","ts":"2023-06-01T13:23:27Z","msg":"Stopping and waiting for non leader election runnables"}                                                                                                                                │
│ {"level":"info","ts":"2023-06-01T13:23:27Z","msg":"Stopping and waiting for leader election runnables"}                                                                                                                                    │
│ {"level":"error","ts":"2023-06-01T13:23:27Z","msg":"error received after stop sequence was engaged","error":"failed to wait for node caches to sync: timed out waiting for cache to be synced","stacktrace":"sigs.k8s.io/controller-runtim │
│ {"level":"error","ts":"2023-06-01T13:23:27Z","msg":"error received after stop sequence was engaged","error":"failed to wait for service caches to sync: timed out waiting for cache to be synced","stacktrace":"sigs.k8s.io/controller-run │
│ {"level":"info","ts":"2023-06-01T13:23:27Z","msg":"Stopping and waiting for caches"}                                                                                                                                                       │
│ {"level":"error","ts":"2023-06-01T13:23:27Z","logger":"controller-runtime.source","msg":"failed to get informer from cache","error":"Timeout: failed waiting for *v1.ConfigMap Informer to sync","stacktrace":"sigs.k8s.io/controller-runt │
│ {"level":"info","ts":"2023-06-01T13:23:27Z","msg":"Stopping and waiting for webhooks"}                                                                                                                                                     │
│ {"level":"info","ts":"2023-06-01T13:23:27Z","msg":"Wait completed, proceeding to shutdown the manager"}                                                                                                                                    │
│ {"caller":"main.go:201","error":"failed to wait for bgppeer caches to sync: timed out waiting for cache to be synced","level":"error","msg":"failed to run k8s client","op":"startup","ts":"2023-06-01T13:23:27Z"} 
```