### PR TITLE
Revert "chore(deps): update docker image quay.io/cilium/hubble-relay to v1.14.0"

### DIFF
--- a/projects/core/values/cilium.yaml
+++ b/projects/core/values/cilium.yaml
@@ -559,7 +559,7 @@ hubble:
     image:
       override: ~
       repository: "quay.io/cilium/hubble-relay"
-      tag: "v1.14.0"
+      tag: "v1.13.5"
        # hubble-relay-digest
       digest: ""
       useDigest: false


### PR DESCRIPTION
Reverts Nold360/hive-apps#1765