### PR TITLE
feat(argocd): public ingress for /api/webhook

### DIFF
--- a/projects/argocd/manifests/webhook-ingress.yaml
+++ b/projects/argocd/manifests/webhook-ingress.yaml
@@ -1,0 +1,36 @@
+# Public ingress that exposes ONLY the ArgoCD webhook endpoint so a push to
+# hive-apps can trigger an immediate refresh, while the ArgoCD UI/API stays
+# behind the internal ingress (argocd.dc).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-webhook
+  namespace: argocd
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/tls-acme: "true"
+    external-dns.alpha.kubernetes.io/hostname: argocd.nold.me
+    external-dns.alpha.kubernetes.io/target: nold.me
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # /api/webhook is unauthenticated unless the shared secret is set; keep
+    # the rate limit tight since the only legitimate caller is the git provider.
+    traefik.ingress.kubernetes.io/rate-limit: "10"
+    traefik.ingress.kubernetes.io/rate-limit-period: "1s"
+spec:
+  ingressClassName: ingress-external
+  tls:
+  - hosts:
+    - argocd.nold.me
+    secretName: argocd-webhook-tls
+  rules:
+  - host: argocd.nold.me
+    http:
+      paths:
+      - path: /api/webhook
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              number: 80


### PR DESCRIPTION
Expose only ArgoCD's webhook endpoint on ingress-external (argocd.nold.me) so git pushes to hive-apps trigger an immediate app refresh instead of waiting for the 3-minute poll. The UI/API stay behind the internal ingress (argocd.dc) — this ingress only routes /api/webhook, with a tight rate limit since /api/webhook is unauthenticated without the shared secret.

Follow-up (out of scope for this PR):
- webhook.github.secret in argocd-secret (Heqet) + matching key in project.yml
- git provider webhook -> https://argocd.nold.me/api/webhook (content-type application/json)