### PR TITLE
fix(ingress-external): restore crowdsec egress in CiliumNetworkPolicy

### DIFF
--- a/projects/ingress-external/manifests/netpol.yaml
+++ b/projects/ingress-external/manifests/netpol.yaml
@@ -1,3 +1,51 @@
+# Egress for the external Traefik ingress controller.
+#
+# Cilium goes deny-all-by-default for egress once ANY policy selects the
+# endpoint, and the allowed set is the UNION of every egress rule from all
+# policies (standard NetworkPolicy + CiliumNetworkPolicy) that select it.
+#
+# The Traefik pod is labeled `app.kubernetes.io/name: traefik` (NOT `name:
+# traefik`). Every endpointSelector below MUST use that label, or the policy
+# silently matches zero endpoints.
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-internet
+  namespace: ingress-external
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  egress:
+  # Broad egress: geojs.io geo lookups (geoblock plugin), Cloudflare (warp
+  # plugin / ACME). `world` covers external destinations only.
+  - toEntities:
+    - world
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-crowdsec
+  namespace: ingress-external
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  egress:
+  # crowdsec-bouncer plugin talks to the LAPI (8080) and appsec (7422).
+  # The crowdsec namespace is NOT labeled environment=external, so this is
+  # the only policy that lets Traefik reach it. Selecting by namespace covers
+  # both the lapi and appsec pods.
+  - toPorts:
+    - ports:
+      - port: "8080"
+        protocol: TCP
+      - port: "7422"
+        protocol: TCP
+    toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: crowdsec
+---
 apiVersion: "cilium.io/v2"
 kind: CiliumNetworkPolicy
 metadata:
@@ -8,6 +56,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: traefik
   egress:
+  # Traefik watches Ingress/IngressRoute/Secret CRDs via the k8s API.
   - toEntities:
     - kube-apiserver
   - toPorts:


### PR DESCRIPTION
## Problem

The crowdsec-bouncer Traefik plugin is failing continuously:

```
ERROR: CrowdsecBouncerTraefikPlugin: ... crowdsecQuery:unreachable
url:http://crowdsec-service.crowdsec.svc.cluster.local:8080/v1/decisions/stream?startup=true
Get ...: context deadline exceeded
```

## Root cause

1. `cc8bc032` (fix: traefik-external netpol) removed the old `allow-crowdsec` egress policy and replaced it with only an `allow-kubeapi` CNP — the crowdsec egress allow was dropped.
2. A hand-applied `allow-crowdsec-lapi` CNP was added afterwards to compensate, but its `endpointSelector` is `name: traefik` — which matches **no pod**. The real Traefik pod label is `app.kubernetes.io/name: traefik`. The CNP selects zero endpoints and is a no-op.
3. Cilium unions egress allows across all policies once an endpoint is selected, and the stale 2024 `allow-external-only` standard NetworkPolicy is still live in the namespace (crowdsec ns is not labeled `environment=external`) — so without a correctly-selecting CNP, crowdsec egress is denied.

## Fix

Restore in GitOps (selecting on the correct pod label):

- `allow-internet` — egress to `world` (geojs.io lookups for the geoblock plugin, Cloudflare for warp/ACME). This CNP was previously kubectl-applied by hand and never committed.
- `allow-crowdsec` — egress to the crowdsec namespace on 8080 (LAPI) and 7422 (appsec), covering both pods.
- `allow-kubeapi` — unchanged (kept in file for completeness).

## Follow-up (needs cluster-admin, not possible with current hermes RBAC)

- `kubectl delete cnp allow-crowdsec-lapi -n ingress-external` — the broken hand-applied CNP (no-op, safe to remove).
- Consider deleting the stale hand-applied `allow-external-only` standard NetworkPolicy (created 2024, never in GitOps) — it is redundant now that all egress is managed via CNPs, but it is harmless while the CNPs are in place.